### PR TITLE
Test for glibc compatibility before downloading linux binary.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@clangd/install",
-  "version": "0.0.0",
+  "version": "0.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "0.1.2",
   "description": "Installing clangd binaries from editor plugins.",
   "main": "out/src/index.js",
-  "files": ["out/src/index.d.ts"],
+  "files": [
+    "out/src/index.d.ts"
+  ],
   "scripts": {
     "compile": "tsc -watch -p ./",
     "test": "tsc -p ./ && tape -r source-map-support/register 'out/test/**/*.js' | tap-spec",

--- a/src/index.ts
+++ b/src/index.ts
@@ -337,7 +337,7 @@ function released(release: Github.Release): semver.Range {
              : new semver.Range(release.tag_name, loose);
 }
 
-// Get the version of glibc from the current (linux) system.
+// Detect the (linux) system's glibc version. If older than `min`, return it.
 export async function oldGlibc(min: semver.Range): Promise<semver.Range|null> {
   // ldd is distributed with glibc, so ldd --version should be a good proxy.
   const output = await run(lddCommand, ['--version']);
@@ -359,13 +359,13 @@ export async function oldGlibc(min: semver.Range): Promise<semver.Range|null> {
 async function run(command: string, flags: string[]): Promise<string> {
   const child = child_process.spawn(command, flags,
                                     {stdio: ['ignore', 'pipe', 'ignore']});
-  var output = '';
+  let output = '';
   for await (const chunk of child.stdout)
     output += chunk;
   return output;
 }
 
-export function rangeGreater(newVer: semver.Range, oldVer: semver.Range) {
+function rangeGreater(newVer: semver.Range, oldVer: semver.Range) {
   return semver.gtr(semver.minVersion(newVer), oldVer);
 }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,7 +88,7 @@ export async function installLatest(ui: UI) {
   const abort = new AbortController();
   try {
     const release = await Github.latestRelease();
-    const asset = Github.chooseAsset(release);
+    const asset = await Github.chooseAsset(release);
     ui.clangdPath = await Install.install(release, asset, abort, ui);
     ui.promptReload(`clangd ${release.name} is now installed.`);
   } catch (e) {
@@ -106,7 +106,7 @@ export async function checkUpdates(requested: boolean, ui: UI) {
   // Gather all the version information to see if there's an upgrade.
   try {
     var release = await Github.latestRelease();
-    Github.chooseAsset(release); // Ensure we have a binary for this platform.
+    await Github.chooseAsset(release); // Ensure a binary for this platform.
     var upgrade = await Version.upgrade(release, ui.clangdPath);
   } catch (e) {
     console.log('Failed to check for clangd update: ', e);
@@ -133,7 +133,7 @@ export async function checkUpdates(requested: boolean, ui: UI) {
 async function recover(ui: UI) {
   try {
     const release = await Github.latestRelease();
-    Github.chooseAsset(release); // Ensure binary available for this platform.
+    await Github.chooseAsset(release); // Ensure a binary for this platform.
     ui.promptInstall(release.name);
   } catch (e) {
     console.error('Auto-install failed: ', e);
@@ -147,6 +147,8 @@ let githubReleaseURL =
     'https://api.github.com/repos/clangd/clangd/releases/latest';
 // Set a fake URL for testing.
 export function fakeGitHubReleaseURL(u: string) { githubReleaseURL = u; }
+let lddCommand = 'ldd';
+export function fakeLddCommand(l: string) { lddCommand = l; }
 
 // Bits for talking to github's release API
 namespace Github {
@@ -168,13 +170,25 @@ export async function latestRelease(): Promise<Release> {
 }
 
 // Determine which release asset should be installed for this machine.
-export function chooseAsset(release: Github.Release): Github.Asset|null {
+export async function chooseAsset(release: Github.Release):
+    Promise<Github.Asset> {
   const variants: {[key: string]: string} = {
     'win32': 'windows',
     'linux': 'linux',
     'darwin': 'mac',
   };
   const variant = variants[os.platform()];
+  if (variant == 'linux') {
+    // Hardcoding this here is sad, but we'd like to offer a nice error message
+    // without making the user download the package first.
+    const minGlibc = new semver.Range('2.18');
+    const oldGlibc = await Version.oldGlibc(minGlibc);
+    if (oldGlibc) {
+      throw new Error('The clangd release is not compatible with your system ' +
+                      `(glibc ${oldGlibc.raw} < ${minGlibc.raw}). ` +
+                      'Try to install it using your package manager instead.');
+    }
+  }
   // 32-bit vscode is still common on 64-bit windows, so don't reject that.
   if (variant && (os.arch() == 'x64' || variant == 'windows')) {
     const asset = release.assets.find(a => a.name.indexOf(variant) >= 0);
@@ -299,31 +313,59 @@ export async function upgrade(release: Github.Release, clangdPath: string) {
   };
 }
 
+const loose: semver.Options = {
+  'loose': true
+};
+
 // Get the version of an installed clangd binary using `clangd --version`.
 async function installed(clangdPath: string): Promise<semver.Range> {
-  const child = child_process.spawn(clangdPath, ['--version'],
-                                    {stdio: ['ignore', 'pipe', 'ignore']});
-  var output = '';
-  for await (const chunk of child.stdout)
-    output += chunk;
+  const output = await run(clangdPath, ['--version']);
   console.log(clangdPath, ' --version output: ', output);
   const prefix = 'clangd version ';
   if (!output.startsWith(prefix))
     throw new Error(`Couldn't parse clangd --version output: ${output}`);
   const rawVersion = output.substr(prefix.length).split(' ', 1)[0];
-  return new semver.Range(rawVersion);
+  return new semver.Range(rawVersion, loose);
 }
 
 // Get the version of a github release, by parsing the tag or name.
 function released(release: Github.Release): semver.Range {
   // Prefer the tag name, but fall back to the release name.
-  return (!semver.validRange(release.tag_name) &&
-          semver.validRange(release.name))
-             ? new semver.Range(release.name)
-             : new semver.Range(release.tag_name);
+  return (!semver.validRange(release.tag_name, loose) &&
+          semver.validRange(release.name, loose))
+             ? new semver.Range(release.name, loose)
+             : new semver.Range(release.tag_name, loose);
 }
 
-function rangeGreater(newVer: semver.Range, oldVer: semver.Range) {
+// Get the version of glibc from the current (linux) system.
+export async function oldGlibc(min: semver.Range): Promise<semver.Range|null> {
+  // ldd is distributed with glibc, so ldd --version should be a good proxy.
+  const output = await run(lddCommand, ['--version']);
+  // The first line is e.g. "ldd (Debian GLIBC 2.29-9) 2.29".
+  const line = output.split('\n', 1)[0];
+  // Require some confirmation this is [e]glibc, and a plausible
+  // version number.
+  const match = line.match(/^ldd .*glibc.* (\d+(?:\.\d+)+)[^ ]*$/i);
+  if (!match || !semver.validRange(match[1], loose)) {
+    console.error(`Can't glibc version from ldd --version output: ${line}`);
+    return null;
+  }
+  const version = new semver.Range(match[1], loose);
+  console.log('glibc is', version.raw, 'min is', min.raw);
+  return rangeGreater(min, version) ? version : null;
+}
+
+// Run a system command and capture any stdout produced.
+async function run(command: string, flags: string[]): Promise<string> {
+  const child = child_process.spawn(command, flags,
+                                    {stdio: ['ignore', 'pipe', 'ignore']});
+  var output = '';
+  for await (const chunk of child.stdout)
+    output += chunk;
+  return output;
+}
+
+export function rangeGreater(newVer: semver.Range, oldVer: semver.Range) {
   return semver.gtr(semver.minVersion(newVer), oldVer);
 }
 }

--- a/test/assets/ldd/exact
+++ b/test/assets/ldd/exact
@@ -1,0 +1,8 @@
+#!/bin/sh
+if [ X"$1" = X"--version" ]; then
+  echo "ldd (glibc) 2.18"
+  echo "And here is a copyright notice."
+else
+  echo "Unexpected usage"
+  exit 1
+fi

--- a/test/assets/ldd/new
+++ b/test/assets/ldd/new
@@ -1,0 +1,8 @@
+#!/bin/sh
+if [ X"$1" = X"--version" ]; then
+  echo "ldd (Debian GLIBC 2.29-9) 2.29"
+  echo "And here is a copyright notice."
+else
+  echo "Unexpected usage"
+  exit 1
+fi

--- a/test/assets/ldd/not-glibc
+++ b/test/assets/ldd/not-glibc
@@ -1,0 +1,8 @@
+#!/bin/sh
+if [ X"$1" = X"--version" ]; then
+  echo "musl libc (x86_64)"
+  echo "And here is a copyright notice."
+else
+  echo "Unexpected usage"
+  exit 1
+fi

--- a/test/assets/ldd/old
+++ b/test/assets/ldd/old
@@ -1,0 +1,8 @@
+#!/bin/sh
+if [ X"$1" = X"--version" ]; then
+  echo "ldd (Ancient EGLIBC 2.15) 2.15-old"
+  echo "And here is a copyright notice."
+else
+  echo "Unexpected usage"
+  exit 1
+fi

--- a/test/index.ts
+++ b/test/index.ts
@@ -11,6 +11,7 @@ const oldClangd = process.cwd() + '/test/assets/fake-clangd-5/clangd';
 const newClangd = process.cwd() + '/test/assets/fake-clangd-15/clangd';
 const unversionedClangd =
     process.cwd() + '/test/assets/fake-clangd-unversioned/clangd';
+const exactLdd = process.cwd() + '/test/assets/ldd/exact';
 const oldLdd = process.cwd() + '/test/assets/ldd/old';
 const newLdd = process.cwd() + '/test/assets/ldd/new';
 const notGlibcLdd = process.cwd() + '/test/assets/ldd/not-glibc';
@@ -77,7 +78,7 @@ function test(name: string,
                          .listen(9999, '127.0.0.1', async () => {
                            console.log('Fake github serving...');
                            install.fakeGitHubReleaseURL(releases);
-                           install.fakeLddCommand(newLdd);
+                           install.fakeLddCommand(exactLdd);
                            try {
                              await body(assert, ui);
                            } catch (e) {
@@ -119,6 +120,13 @@ test('install: no binary for platform', async (assert, ui) => {
 });
 
 if (os.platform() == 'linux') {
+  test('install: new glibc', async (assert, ui) => {
+    install.fakeLddCommand(newLdd);
+    await install.installLatest(ui);
+
+    assert.deepEqual(ui.events, ['progress', 'slow', 'promptReload']);
+  });
+
   test('install: old glibc', async (assert, ui) => {
     install.fakeLddCommand(oldLdd);
     await install.installLatest(ui);

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,16 +1,19 @@
 import * as fs from 'fs';
 import * as http from 'http';
 import * as nodeStatic from 'node-static';
+import * as os from 'os';
 import * as path from 'path';
 import * as tape from 'tape';
 import * as tmp from 'tmp-promise';
-
 import * as install from '../src/index';
 
 const oldClangd = process.cwd() + '/test/assets/fake-clangd-5/clangd';
 const newClangd = process.cwd() + '/test/assets/fake-clangd-15/clangd';
 const unversionedClangd =
     process.cwd() + '/test/assets/fake-clangd-unversioned/clangd';
+const oldLdd = process.cwd() + '/test/assets/ldd/old';
+const newLdd = process.cwd() + '/test/assets/ldd/new';
+const notGlibcLdd = process.cwd() + '/test/assets/ldd/not-glibc';
 const missingClangd = process.cwd() + '/test/assets/missing/clangd';
 const releases = 'http://127.0.0.1:9999/release.json';
 const incompatibleReleases = 'http://127.0.0.1:9999/release-incompatible.json';
@@ -74,6 +77,7 @@ function test(name: string,
                          .listen(9999, '127.0.0.1', async () => {
                            console.log('Fake github serving...');
                            install.fakeGitHubReleaseURL(releases);
+                           install.fakeLddCommand(newLdd);
                            try {
                              await body(assert, ui);
                            } catch (e) {
@@ -113,6 +117,23 @@ test('install: no binary for platform', async (assert, ui) => {
               'clangdPath unmodified');
   assert.deepEqual(ui.events, ['showHelp']);
 });
+
+if (os.platform() == 'linux') {
+  test('install: old glibc', async (assert, ui) => {
+    install.fakeLddCommand(oldLdd);
+    await install.installLatest(ui);
+
+    assert.deepEqual(ui.events, ['showHelp'], 'not installed due to old glibc');
+  });
+
+  test('install: unknown glibc', async (assert, ui) => {
+    install.fakeLddCommand(notGlibcLdd);
+    await install.installLatest(ui);
+
+    // Installed. It may not work, but also maybe our detection just failed.
+    assert.deepEqual(ui.events, ['progress', 'slow', 'promptReload']);
+  });
+}
 
 test('install: reuse existing install', async (assert, ui) => {
   const existing = path.join(ui.storagePath, 'install', '10.0', 'weird-dir');


### PR DESCRIPTION
The binary releases are statically linked except for glibc, they require
version 2.18 or later. This means we're not compatible with RHEL/Centos 6/7.
Rather than offer the download and have it mysteriously fail, treat this
like no package for the platform (but with a different message).

We detect this by running ldd --version and parsing the output (as ldd is
part of glibc). If this fails or isn't glibc, we continue with the install.