### PR TITLE
Download mac binaries also on darwin-arm64 (M1 chip)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clangd/install",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Installing clangd binaries from editor plugins.",
   "main": "out/src/index.js",
   "files": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -190,7 +190,10 @@ export async function chooseAsset(release: Github.Release):
     }
   }
   // 32-bit vscode is still common on 64-bit windows, so don't reject that.
-  if (variant && (os.arch() == 'x64' || variant == 'windows')) {
+  if (variant && (os.arch() == 'x64' || variant == 'windows' ||
+                  // Mac distribution contains a fat binary working on both x64
+                  // and arm64s.
+                  (os.arch() == 'arm64' && variant == 'mac'))) {
     const asset = release.assets.find(a => a.name.indexOf(variant) >= 0);
     if (asset)
       return asset;


### PR DESCRIPTION
Note that we first need to swap clangd-darwin-fat with clangd-mac in
https://github.com/clangd/clangd/releases/tag/12.0.0.
