### PR TITLE
Add the `localize` function for the type UI. 

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -55,8 +55,16 @@ type UI = {
               work: (progress: (fraction: number) => void) => Promise<T>):
       Promise<T>;
 
-  // Message l10n
-  localize(message: string, ...args: string[]): string;
+  /**
+   * Get localization string.
+   * @param message - The message to localize. Supports index templating where strings like `{0}` and `{1}` are
+   * replaced by the item at that index in the {@link args} array.
+   * @param args - The arguments to be used in the localized string. The index of the argument is used to
+   * match the template placeholder in the localized string.
+   * @returns localized string with injected arguments.
+   * @example `l10n.t('Hello {0}!', 'World');`
+   */
+  localize(message: string, ...args: Array<string | number | boolean>): string;
 }
 
 type InstallStatus = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@
 //  - checking for updates (manual or automatic)
 //  - no usable clangd found, try to recover
 // These have different flows, but the same underlying mechanisms.
-import { AbortController } from 'abort-controller';
+import {AbortController} from 'abort-controller';
 import * as AdmZip from 'adm-zip';
 import * as child_process from 'child_process';
 import * as fs from 'fs';
@@ -19,7 +19,7 @@ import * as readdirp from 'readdirp';
 import * as rimraf from 'rimraf';
 import * as semver from 'semver';
 import * as stream from 'stream';
-import { promisify } from 'util';
+import {promisify} from 'util';
 import * as which from 'which';
 
 // Abstracts the editor UI and configuration.
@@ -46,30 +46,32 @@ type UI = {
   promptInstall(version: string): void;
   // Ask whether to reuse rather than overwrite an existing clangd installation.
   // Undefined means no choice was made, so we shouldn't do either.
-  shouldReuse(path: string): Promise<boolean | undefined>;
+  shouldReuse(path: string): Promise<boolean|undefined>;
 
   // `work` may take a while to resolve, indicate we're doing something.
   slow<T>(title: string, work: Promise<T>): Promise<T>;
   // `work` will take a while to run and can indicate fractional progress.
-  progress<T>(title: string, cancel: AbortController | null,
-    work: (progress: (fraction: number) => void) => Promise<T>):
-    Promise<T>;
+  progress<T>(title: string, cancel: AbortController|null,
+              work: (progress: (fraction: number) => void) => Promise<T>):
+      Promise<T>;
 
   /**
    * Get localization string.
-   * @param message - The message to localize. Supports index templating where strings like `{0}` and `{1}` are
+   * @param message - The message to localize. Supports index templating where
+   *     strings like `{0}` and `{1}` are
    * replaced by the item at that index in the {@link args} array.
-   * @param args - The arguments to be used in the localized string. The index of the argument is used to
+   * @param args - The arguments to be used in the localized string. The index
+   *     of the argument is used to
    * match the template placeholder in the localized string.
    * @returns localized string with injected arguments.
    * @example `localize('Hello {0}!', 'World');`
    */
-  localize(message: string, ...args: Array<string | number | boolean>): string;
+  localize(message: string, ...args: Array<string|number|boolean>): string;
 }
 
 type InstallStatus = {
   // Absolute path to clangd, or null if no valid clangd binary is configured.
-  clangdPath: string | null;
+  clangdPath: string|null;
   // Background tasks that were started, exposed for testing.
   background: Promise<void>;
 };
@@ -77,7 +79,7 @@ type InstallStatus = {
 // Main startup workflow: check whether the configured clangd binary us usable.
 // If not, offer to install one. If so, check for updates.
 export async function prepare(ui: UI,
-  checkUpdate: boolean): Promise<InstallStatus> {
+                              checkUpdate: boolean): Promise<InstallStatus> {
   let clangdPath = ui.clangdPath;
   try {
     if (path.isAbsolute(clangdPath)) {
@@ -87,13 +89,13 @@ export async function prepare(ui: UI,
     }
   } catch (e) {
     // Couldn't find clangd - start recovery flow and stop extension loading.
-    return { clangdPath: null, background: recover(ui) };
+    return {clangdPath: null, background: recover(ui)};
   }
   // Allow extension to load, asynchronously check for updates.
   return {
     clangdPath,
     background: checkUpdate ? checkUpdates(/*requested=*/ false, ui)
-      : Promise.resolve()
+                            : Promise.resolve()
   };
 }
 
@@ -109,7 +111,9 @@ export async function installLatest(ui: UI) {
   } catch (e) {
     if (!abort.signal.aborted) {
       console.error('Failed to install clangd: ', e);
-      const message = ui.localize('Failed to install clangd language server: {0}\nYou may want to install it manually.', e)
+      const message = ui.localize(
+          'Failed to install clangd language server: {0}\nYou may want to install it manually.',
+          e)
       ui.showHelp(message, installURL);
     }
   }
@@ -130,11 +134,12 @@ export async function checkUpdates(requested: boolean, ui: UI) {
     return;
   }
   console.log('Checking for clangd update: available=', upgrade.new,
-    ' installed=', upgrade.old);
+              ' installed=', upgrade.old);
   // Bail out if the new version is better or comparable.
   if (!upgrade.upgrade) {
     if (requested)
-      ui.info(ui.localize('clangd is up-to-date (you have {0}, latest is {1})', upgrade.old, upgrade.new));
+      ui.info(ui.localize('clangd is up-to-date (you have {0}, latest is {1})',
+                          upgrade.old, upgrade.new));
     return;
   }
   ui.promptUpdate(upgrade.old, upgrade.new);
@@ -150,14 +155,15 @@ async function recover(ui: UI) {
     ui.promptInstall(release.name);
   } catch (e) {
     console.error('Auto-install failed: ', e);
-    ui.showHelp(ui.localize('The clangd language server is not installed.'), installURL);
+    ui.showHelp(ui.localize('The clangd language server is not installed.'),
+                installURL);
   }
 }
 
 const installURL = 'https://clangd.llvm.org/installation.html';
 // The GitHub API endpoint for the latest binary clangd release.
 let githubReleaseURL =
-  'https://api.github.com/repos/clangd/clangd/releases/latest';
+    'https://api.github.com/repos/clangd/clangd/releases/latest';
 // Set a fake URL for testing.
 export function fakeGitHubReleaseURL(u: string) { githubReleaseURL = u; }
 let lddCommand = 'ldd';
@@ -165,62 +171,63 @@ export function fakeLddCommand(l: string) { lddCommand = l; }
 
 // Bits for talking to github's release API
 namespace Github {
-  export interface Release {
-    name: string, tag_name: string, assets: Array<Asset>,
-  }
-  export interface Asset {
-    name: string, browser_download_url: string,
-  }
+export interface Release {
+  name: string, tag_name: string, assets: Array<Asset>,
+}
+export interface Asset {
+  name: string, browser_download_url: string,
+}
 
-  // Fetch the metadata for the latest stable clangd release.
-  export async function latestRelease(): Promise<Release> {
-    const timeoutController = new AbortController();
-    const timeout = setTimeout(() => { timeoutController.abort(); }, 5000);
-    try {
-      const response =
-        await fetch(githubReleaseURL, { signal: timeoutController.signal });
-      if (!response.ok) {
-        console.log(response.url, response.status, response.statusText);
-        throw new Error(`Can't fetch release: ${response.statusText}`);
-      }
-      return await response.json() as Release;
-    } finally {
-      clearTimeout(timeout);
+// Fetch the metadata for the latest stable clangd release.
+export async function latestRelease(): Promise<Release> {
+  const timeoutController = new AbortController();
+  const timeout = setTimeout(() => { timeoutController.abort(); }, 5000);
+  try {
+    const response =
+        await fetch(githubReleaseURL, {signal: timeoutController.signal});
+    if (!response.ok) {
+      console.log(response.url, response.status, response.statusText);
+      throw new Error(`Can't fetch release: ${response.statusText}`);
     }
+    return await response.json() as Release;
+  } finally {
+    clearTimeout(timeout);
   }
+}
 
-  // Determine which release asset should be installed for this machine.
-  export async function chooseAsset(release: Github.Release):
+// Determine which release asset should be installed for this machine.
+export async function chooseAsset(release: Github.Release):
     Promise<Github.Asset> {
-    const variants: { [key: string]: string } = {
-      'win32': 'windows',
-      'linux': 'linux',
-      'darwin': 'mac',
-    };
-    const variant = variants[os.platform()];
-    if (variant == 'linux') {
-      // Hardcoding this here is sad, but we'd like to offer a nice error message
-      // without making the user download the package first.
-      const minGlibc = new semver.Range('2.18');
-      const oldGlibc = await Version.oldGlibc(minGlibc);
-      if (oldGlibc) {
-        throw new Error('The clangd release is not compatible with your system ' +
-          `(glibc ${oldGlibc.raw} < ${minGlibc.raw}). ` +
-          'Try to install it using your package manager instead.');
-      }
+  const variants: {[key: string]: string} = {
+    'win32': 'windows',
+    'linux': 'linux',
+    'darwin': 'mac',
+  };
+  const variant = variants[os.platform()];
+  if (variant == 'linux') {
+    // Hardcoding this here is sad, but we'd like to offer a nice error message
+    // without making the user download the package first.
+    const minGlibc = new semver.Range('2.18');
+    const oldGlibc = await Version.oldGlibc(minGlibc);
+    if (oldGlibc) {
+      throw new Error('The clangd release is not compatible with your system ' +
+                      `(glibc ${oldGlibc.raw} < ${minGlibc.raw}). ` +
+                      'Try to install it using your package manager instead.');
     }
-    // 32-bit vscode is still common on 64-bit windows, so don't reject that.
-    if (variant && (os.arch() == 'x64' || variant == 'windows' ||
-      // Mac distribution contains a fat binary working on both x64
-      // and arm64s.
-      (os.arch() == 'arm64' && variant == 'mac'))) {
-      const substr = 'clangd-' + variant;
-      const asset = release.assets.find(a => a.name.indexOf(substr) >= 0);
-      if (asset)
-        return asset;
-    }
-    throw new Error(`No clangd ${release.name} binary available for ${os.platform()}/${os.arch()}`);
   }
+  // 32-bit vscode is still common on 64-bit windows, so don't reject that.
+  if (variant && (os.arch() == 'x64' || variant == 'windows' ||
+                  // Mac distribution contains a fat binary working on both x64
+                  // and arm64s.
+                  (os.arch() == 'arm64' && variant == 'mac'))) {
+    const substr = 'clangd-' + variant;
+    const asset = release.assets.find(a => a.name.indexOf(substr) >= 0);
+    if (asset)
+      return asset;
+  }
+  throw new Error(`No clangd ${release.name} binary available for ${
+      os.platform()}/${os.arch()}`);
+}
 }
 
 // Functions to download and install the releases, and manage the files on disk.
@@ -235,71 +242,73 @@ namespace Github {
 //    download/
 //      clangd-platform-<version>.zip  (deleted after extraction)
 namespace Install {
-  // Download the binary archive `asset` from a github `release` and extract it
-  // to the extension's global storage location.
-  // The `abort` controller is signaled if the user cancels the installation.
-  // Returns the absolute path to the installed clangd executable.
-  export async function install(release: Github.Release, asset: Github.Asset,
-    abort: AbortController, ui: UI): Promise<string> {
-    const dirs = await createDirs(ui);
-    const extractRoot = path.join(dirs.install, release.tag_name);
-    if (await promisify(fs.exists)(extractRoot)) {
-      const reuse = await ui.shouldReuse(release.name);
-      if (reuse === undefined) {
-        // User dismissed prompt, bail out.
-        abort.abort();
-        throw new Error(`clangd ${release.name} already installed!`);
-      }
-      if (reuse) {
-        // Find clangd within the existing directory.
-        let files = (await readdirp.promise(extractRoot)).map(e => e.fullPath);
-        return findExecutable(files);
-      } else {
-        // Delete the old version.
-        await promisify(rimraf)(extractRoot);
-        // continue with installation.
-      }
+// Download the binary archive `asset` from a github `release` and extract it
+// to the extension's global storage location.
+// The `abort` controller is signaled if the user cancels the installation.
+// Returns the absolute path to the installed clangd executable.
+export async function install(release: Github.Release, asset: Github.Asset,
+                              abort: AbortController, ui: UI): Promise<string> {
+  const dirs = await createDirs(ui);
+  const extractRoot = path.join(dirs.install, release.tag_name);
+  if (await promisify(fs.exists)(extractRoot)) {
+    const reuse = await ui.shouldReuse(release.name);
+    if (reuse === undefined) {
+      // User dismissed prompt, bail out.
+      abort.abort();
+      throw new Error(`clangd ${release.name} already installed!`);
     }
-    const zipFile = path.join(dirs.download, asset.name);
-    await download(asset.browser_download_url, zipFile, abort, ui);
-    const zip = new AdmZip(zipFile);
-    await ui.slow(ui.localize('Extracting {0}', asset.name), new Promise(resolve => {
-      zip.extractAllToAsync(extractRoot, true, false, resolve);
-    }));
-    const executable = findExecutable(zip.getEntries().map(e => e.entryName));
-    const clangdPath = path.join(extractRoot, executable);
-    await fs.promises.chmod(clangdPath, 0o755);
-    await fs.promises.unlink(zipFile);
-    return clangdPath;
+    if (reuse) {
+      // Find clangd within the existing directory.
+      let files = (await readdirp.promise(extractRoot)).map(e => e.fullPath);
+      return findExecutable(files);
+    } else {
+      // Delete the old version.
+      await promisify(rimraf)(extractRoot);
+      // continue with installation.
+    }
   }
+  const zipFile = path.join(dirs.download, asset.name);
+  await download(asset.browser_download_url, zipFile, abort, ui);
+  const zip = new AdmZip(zipFile);
+  await ui.slow(ui.localize('Extracting {0}', asset.name),
+                new Promise(resolve => {
+                  zip.extractAllToAsync(extractRoot, true, false, resolve);
+                }));
+  const executable = findExecutable(zip.getEntries().map(e => e.entryName));
+  const clangdPath = path.join(extractRoot, executable);
+  await fs.promises.chmod(clangdPath, 0o755);
+  await fs.promises.unlink(zipFile);
+  return clangdPath;
+}
 
-  // Create the 'install' and 'download' directories, and return absolute paths.
-  async function createDirs(ui: UI) {
-    const install = path.join(ui.storagePath, 'install');
-    const download = path.join(ui.storagePath, 'download');
-    for (const dir of [install, download])
-      await fs.promises.mkdir(dir, { 'recursive': true });
-    return { install: install, download: download };
-  }
+// Create the 'install' and 'download' directories, and return absolute paths.
+async function createDirs(ui: UI) {
+  const install = path.join(ui.storagePath, 'install');
+  const download = path.join(ui.storagePath, 'download');
+  for (const dir of [install, download])
+    await fs.promises.mkdir(dir, {'recursive': true});
+  return {install: install, download: download};
+}
 
-  // Find the clangd executable within a set of files.
-  function findExecutable(paths: string[]): string {
-    const filename = os.platform() == 'win32' ? 'clangd.exe' : 'clangd';
-    const entry = paths.find(f => path.posix.basename(f) == filename ||
-      path.win32.basename(f) == filename);
-    if (entry == null)
-      throw new Error('Didn\'t find a clangd executable!');
-    return entry;
-  }
+// Find the clangd executable within a set of files.
+function findExecutable(paths: string[]): string {
+  const filename = os.platform() == 'win32' ? 'clangd.exe' : 'clangd';
+  const entry = paths.find(f => path.posix.basename(f) == filename ||
+                                path.win32.basename(f) == filename);
+  if (entry == null)
+    throw new Error('Didn\'t find a clangd executable!');
+  return entry;
+}
 
-  // Downloads `url` to a local file `dest` (whose parent should exist).
-  // A progress dialog is shown, if it is cancelled then `abort` is signaled.
-  async function download(url: string, dest: string, abort: AbortController,
-    ui: UI): Promise<void> {
-    console.log('Downloading ', url, ' to ', dest);
-    return ui.progress(
-      ui.localize('Downloading {0}', path.basename(dest)), abort, async (progress) => {
-        const response = await fetch(url, { signal: abort.signal });
+// Downloads `url` to a local file `dest` (whose parent should exist).
+// A progress dialog is shown, if it is cancelled then `abort` is signaled.
+async function download(url: string, dest: string, abort: AbortController,
+                        ui: UI): Promise<void> {
+  console.log('Downloading ', url, ' to ', dest);
+  return ui.progress(
+      ui.localize('Downloading {0}', path.basename(dest)), abort,
+      async (progress) => {
+        const response = await fetch(url, {signal: abort.signal});
         if (!response.ok)
           throw new Error(`Failed to download ${url}`);
         const size = Number(response.headers.get('content-length'));
@@ -315,7 +324,7 @@ namespace Install {
           throw e;
         });
       });
-  }
+}
 }
 
 // Functions dealing with clangd versions.
@@ -327,76 +336,76 @@ namespace Install {
 // These functions throw if versions can't be parsed (e.g. installed clangd
 // is a vendor-modified version).
 namespace Version {
-  export async function upgrade(release: Github.Release, clangdPath: string) {
-    const releasedVer = released(release);
-    const installedVer = await installed(clangdPath);
-    return {
-      old: installedVer.raw,
-      new: releasedVer.raw,
-      upgrade: rangeGreater(releasedVer, installedVer)
-    };
-  }
-
-  const loose: semver.Options = {
-    'loose': true
+export async function upgrade(release: Github.Release, clangdPath: string) {
+  const releasedVer = released(release);
+  const installedVer = await installed(clangdPath);
+  return {
+    old: installedVer.raw,
+    new: releasedVer.raw,
+    upgrade: rangeGreater(releasedVer, installedVer)
   };
+}
 
-  // Get the version of an installed clangd binary using `clangd --version`.
-  async function installed(clangdPath: string): Promise<semver.Range> {
-    const output = await run(clangdPath, ['--version']);
-    console.log(clangdPath, ' --version output: ', output);
-    const prefix = 'clangd version ';
-    const pos = output.indexOf(prefix);
-    if (pos < 0)
-      throw new Error(`Couldn't parse clangd --version output: ${output}`);
-    if (pos > 0) {
-      const vendor = output.substring(0, pos).trim();
-      if (vendor == 'Apple')
-        throw new Error(`Cannot compare vendor's clangd version: ${output}`);
-    }
-    // Some vendors add trailing ~patchlevel, ignore this.
-    const rawVersion = output.substr(pos + prefix.length).split(/\s|~/, 1)[0];
-    return new semver.Range(rawVersion, loose);
-  }
+const loose: semver.Options = {
+  'loose': true
+};
 
-  // Get the version of a github release, by parsing the tag or name.
-  function released(release: Github.Release): semver.Range {
-    // Prefer the tag name, but fall back to the release name.
-    return (!semver.validRange(release.tag_name, loose) &&
-      semver.validRange(release.name, loose))
-      ? new semver.Range(release.name, loose)
-      : new semver.Range(release.tag_name, loose);
+// Get the version of an installed clangd binary using `clangd --version`.
+async function installed(clangdPath: string): Promise<semver.Range> {
+  const output = await run(clangdPath, ['--version']);
+  console.log(clangdPath, ' --version output: ', output);
+  const prefix = 'clangd version ';
+  const pos = output.indexOf(prefix);
+  if (pos < 0)
+    throw new Error(`Couldn't parse clangd --version output: ${output}`);
+  if (pos > 0) {
+    const vendor = output.substring(0, pos).trim();
+    if (vendor == 'Apple')
+      throw new Error(`Cannot compare vendor's clangd version: ${output}`);
   }
+  // Some vendors add trailing ~patchlevel, ignore this.
+  const rawVersion = output.substr(pos + prefix.length).split(/\s|~/, 1)[0];
+  return new semver.Range(rawVersion, loose);
+}
 
-  // Detect the (linux) system's glibc version. If older than `min`, return it.
-  export async function oldGlibc(min: semver.Range): Promise<semver.Range | null> {
-    // ldd is distributed with glibc, so ldd --version should be a good proxy.
-    const output = await run(lddCommand, ['--version']);
-    // The first line is e.g. "ldd (Debian GLIBC 2.29-9) 2.29".
-    const line = output.split('\n', 1)[0];
-    // Require some confirmation this is [e]glibc, and a plausible
-    // version number.
-    const match = line.match(/^ldd .*glibc.* (\d+(?:\.\d+)+)[^ ]*$/i);
-    if (!match || !semver.validRange(match[1], loose)) {
-      console.error(`Can't glibc version from ldd --version output: ${line}`);
-      return null;
-    }
-    const version = new semver.Range(match[1], loose);
-    console.log('glibc is', version.raw, 'min is', min.raw);
-    return rangeGreater(min, version) ? version : null;
-  }
+// Get the version of a github release, by parsing the tag or name.
+function released(release: Github.Release): semver.Range {
+  // Prefer the tag name, but fall back to the release name.
+  return (!semver.validRange(release.tag_name, loose) &&
+          semver.validRange(release.name, loose))
+             ? new semver.Range(release.name, loose)
+             : new semver.Range(release.tag_name, loose);
+}
 
-  // Run a system command and capture any stdout produced.
-  async function run(command: string, flags: string[]): Promise<string> {
-    const child = child_process.spawn(command, flags,
-      { stdio: ['ignore', 'pipe', 'ignore'] });
-    let output = '';
-    for await (const chunk of child.stdout)
-      output += chunk;
-    return output;
+// Detect the (linux) system's glibc version. If older than `min`, return it.
+export async function oldGlibc(min: semver.Range): Promise<semver.Range|null> {
+  // ldd is distributed with glibc, so ldd --version should be a good proxy.
+  const output = await run(lddCommand, ['--version']);
+  // The first line is e.g. "ldd (Debian GLIBC 2.29-9) 2.29".
+  const line = output.split('\n', 1)[0];
+  // Require some confirmation this is [e]glibc, and a plausible
+  // version number.
+  const match = line.match(/^ldd .*glibc.* (\d+(?:\.\d+)+)[^ ]*$/i);
+  if (!match || !semver.validRange(match[1], loose)) {
+    console.error(`Can't glibc version from ldd --version output: ${line}`);
+    return null;
   }
+  const version = new semver.Range(match[1], loose);
+  console.log('glibc is', version.raw, 'min is', min.raw);
+  return rangeGreater(min, version) ? version : null;
+}
 
-  function rangeGreater(newVer: semver.Range, oldVer: semver.Range) {
-    return semver.gtr(semver.minVersion(newVer), oldVer);
-  }
+// Run a system command and capture any stdout produced.
+async function run(command: string, flags: string[]): Promise<string> {
+  const child = child_process.spawn(command, flags,
+                                    {stdio: ['ignore', 'pipe', 'ignore']});
+  let output = '';
+  for await (const chunk of child.stdout)
+    output += chunk;
+  return output;
+}
+
+function rangeGreater(newVer: semver.Range, oldVer: semver.Range) {
+  return semver.gtr(semver.minVersion(newVer), oldVer);
+}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@
 //  - checking for updates (manual or automatic)
 //  - no usable clangd found, try to recover
 // These have different flows, but the same underlying mechanisms.
-import {AbortController} from 'abort-controller';
+import { AbortController } from 'abort-controller';
 import * as AdmZip from 'adm-zip';
 import * as child_process from 'child_process';
 import * as fs from 'fs';
@@ -19,7 +19,7 @@ import * as readdirp from 'readdirp';
 import * as rimraf from 'rimraf';
 import * as semver from 'semver';
 import * as stream from 'stream';
-import {promisify} from 'util';
+import { promisify } from 'util';
 import * as which from 'which';
 
 // Abstracts the editor UI and configuration.
@@ -46,14 +46,14 @@ type UI = {
   promptInstall(version: string): void;
   // Ask whether to reuse rather than overwrite an existing clangd installation.
   // Undefined means no choice was made, so we shouldn't do either.
-  shouldReuse(path: string): Promise<boolean|undefined>;
+  shouldReuse(path: string): Promise<boolean | undefined>;
 
   // `work` may take a while to resolve, indicate we're doing something.
   slow<T>(title: string, work: Promise<T>): Promise<T>;
   // `work` will take a while to run and can indicate fractional progress.
-  progress<T>(title: string, cancel: AbortController|null,
-              work: (progress: (fraction: number) => void) => Promise<T>):
-      Promise<T>;
+  progress<T>(title: string, cancel: AbortController | null,
+    work: (progress: (fraction: number) => void) => Promise<T>):
+    Promise<T>;
 
   /**
    * Get localization string.
@@ -62,14 +62,14 @@ type UI = {
    * @param args - The arguments to be used in the localized string. The index of the argument is used to
    * match the template placeholder in the localized string.
    * @returns localized string with injected arguments.
-   * @example `l10n.t('Hello {0}!', 'World');`
+   * @example `localize('Hello {0}!', 'World');`
    */
   localize(message: string, ...args: Array<string | number | boolean>): string;
 }
 
 type InstallStatus = {
   // Absolute path to clangd, or null if no valid clangd binary is configured.
-  clangdPath: string|null;
+  clangdPath: string | null;
   // Background tasks that were started, exposed for testing.
   background: Promise<void>;
 };
@@ -77,7 +77,7 @@ type InstallStatus = {
 // Main startup workflow: check whether the configured clangd binary us usable.
 // If not, offer to install one. If so, check for updates.
 export async function prepare(ui: UI,
-                              checkUpdate: boolean): Promise<InstallStatus> {
+  checkUpdate: boolean): Promise<InstallStatus> {
   let clangdPath = ui.clangdPath;
   try {
     if (path.isAbsolute(clangdPath)) {
@@ -87,13 +87,13 @@ export async function prepare(ui: UI,
     }
   } catch (e) {
     // Couldn't find clangd - start recovery flow and stop extension loading.
-    return {clangdPath: null, background: recover(ui)};
+    return { clangdPath: null, background: recover(ui) };
   }
   // Allow extension to load, asynchronously check for updates.
   return {
     clangdPath,
     background: checkUpdate ? checkUpdates(/*requested=*/ false, ui)
-                            : Promise.resolve()
+      : Promise.resolve()
   };
 }
 
@@ -105,12 +105,11 @@ export async function installLatest(ui: UI) {
     const release = await Github.latestRelease();
     const asset = await Github.chooseAsset(release);
     ui.clangdPath = await Install.install(release, asset, abort, ui);
-    ui.promptReload(ui.localize(`clangd {0} is now installed.`, release.name));
+    ui.promptReload(ui.localize('clangd {0} is now installed.', release.name));
   } catch (e) {
     if (!abort.signal.aborted) {
       console.error('Failed to install clangd: ', e);
-      const message = ui.localize(`Failed to install clangd language server: {0}\n`, e) +
-                      ui.localize('You may want to install it manually.');
+      const message = ui.localize('Failed to install clangd language server: {0}\nYou may want to install it manually.', e)
       ui.showHelp(message, installURL);
     }
   }
@@ -127,15 +126,15 @@ export async function checkUpdates(requested: boolean, ui: UI) {
     console.log('Failed to check for clangd update: ', e);
     // We're not sure whether there's an upgrade: stay quiet unless asked.
     if (requested)
-      ui.error(ui.localize(`Failed to check for clangd update: {0}`, e));
+      ui.error(ui.localize('Failed to check for clangd update: {0}', e));
     return;
   }
   console.log('Checking for clangd update: available=', upgrade.new,
-              ' installed=', upgrade.old);
+    ' installed=', upgrade.old);
   // Bail out if the new version is better or comparable.
   if (!upgrade.upgrade) {
     if (requested)
-      ui.info(ui.localize(`clangd is up-to-date (you have {0}, latest is {1})`, upgrade.old, upgrade.new));
+      ui.info(ui.localize('clangd is up-to-date (you have {0}, latest is {1})', upgrade.old, upgrade.new));
     return;
   }
   ui.promptUpdate(upgrade.old, upgrade.new);
@@ -158,7 +157,7 @@ async function recover(ui: UI) {
 const installURL = 'https://clangd.llvm.org/installation.html';
 // The GitHub API endpoint for the latest binary clangd release.
 let githubReleaseURL =
-    'https://api.github.com/repos/clangd/clangd/releases/latest';
+  'https://api.github.com/repos/clangd/clangd/releases/latest';
 // Set a fake URL for testing.
 export function fakeGitHubReleaseURL(u: string) { githubReleaseURL = u; }
 let lddCommand = 'ldd';
@@ -166,63 +165,62 @@ export function fakeLddCommand(l: string) { lddCommand = l; }
 
 // Bits for talking to github's release API
 namespace Github {
-export interface Release {
-  name: string, tag_name: string, assets: Array<Asset>,
-}
-export interface Asset {
-  name: string, browser_download_url: string,
-}
-
-// Fetch the metadata for the latest stable clangd release.
-export async function latestRelease(): Promise<Release> {
-  const timeoutController = new AbortController();
-  const timeout = setTimeout(() => { timeoutController.abort(); }, 5000);
-  try {
-    const response =
-        await fetch(githubReleaseURL, {signal: timeoutController.signal});
-    if (!response.ok) {
-      console.log(response.url, response.status, response.statusText);
-      throw new Error(`Can't fetch release: ${response.statusText}`);
-    }
-    return await response.json() as Release;
-  } finally {
-    clearTimeout(timeout);
+  export interface Release {
+    name: string, tag_name: string, assets: Array<Asset>,
   }
-}
+  export interface Asset {
+    name: string, browser_download_url: string,
+  }
 
-// Determine which release asset should be installed for this machine.
-export async function chooseAsset(release: Github.Release):
+  // Fetch the metadata for the latest stable clangd release.
+  export async function latestRelease(): Promise<Release> {
+    const timeoutController = new AbortController();
+    const timeout = setTimeout(() => { timeoutController.abort(); }, 5000);
+    try {
+      const response =
+        await fetch(githubReleaseURL, { signal: timeoutController.signal });
+      if (!response.ok) {
+        console.log(response.url, response.status, response.statusText);
+        throw new Error(`Can't fetch release: ${response.statusText}`);
+      }
+      return await response.json() as Release;
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  // Determine which release asset should be installed for this machine.
+  export async function chooseAsset(release: Github.Release):
     Promise<Github.Asset> {
-  const variants: {[key: string]: string} = {
-    'win32': 'windows',
-    'linux': 'linux',
-    'darwin': 'mac',
-  };
-  const variant = variants[os.platform()];
-  if (variant == 'linux') {
-    // Hardcoding this here is sad, but we'd like to offer a nice error message
-    // without making the user download the package first.
-    const minGlibc = new semver.Range('2.18');
-    const oldGlibc = await Version.oldGlibc(minGlibc);
-    if (oldGlibc) {
-      throw new Error('The clangd release is not compatible with your system ' +
-                      `(glibc ${oldGlibc.raw} < ${minGlibc.raw}). ` +
-                      'Try to install it using your package manager instead.');
+    const variants: { [key: string]: string } = {
+      'win32': 'windows',
+      'linux': 'linux',
+      'darwin': 'mac',
+    };
+    const variant = variants[os.platform()];
+    if (variant == 'linux') {
+      // Hardcoding this here is sad, but we'd like to offer a nice error message
+      // without making the user download the package first.
+      const minGlibc = new semver.Range('2.18');
+      const oldGlibc = await Version.oldGlibc(minGlibc);
+      if (oldGlibc) {
+        throw new Error('The clangd release is not compatible with your system ' +
+          `(glibc ${oldGlibc.raw} < ${minGlibc.raw}). ` +
+          'Try to install it using your package manager instead.');
+      }
     }
+    // 32-bit vscode is still common on 64-bit windows, so don't reject that.
+    if (variant && (os.arch() == 'x64' || variant == 'windows' ||
+      // Mac distribution contains a fat binary working on both x64
+      // and arm64s.
+      (os.arch() == 'arm64' && variant == 'mac'))) {
+      const substr = 'clangd-' + variant;
+      const asset = release.assets.find(a => a.name.indexOf(substr) >= 0);
+      if (asset)
+        return asset;
+    }
+    throw new Error(`No clangd ${release.name} binary available for ${os.platform()}/${os.arch()}`);
   }
-  // 32-bit vscode is still common on 64-bit windows, so don't reject that.
-  if (variant && (os.arch() == 'x64' || variant == 'windows' ||
-                  // Mac distribution contains a fat binary working on both x64
-                  // and arm64s.
-                  (os.arch() == 'arm64' && variant == 'mac'))) {
-    const substr = 'clangd-' + variant;
-    const asset = release.assets.find(a => a.name.indexOf(substr) >= 0);
-    if (asset)
-      return asset;
-  }
-  throw new Error(`No clangd ${release.name} binary available for ${
-      os.platform()}/${os.arch()}`);
-}
 }
 
 // Functions to download and install the releases, and manage the files on disk.
@@ -237,71 +235,71 @@ export async function chooseAsset(release: Github.Release):
 //    download/
 //      clangd-platform-<version>.zip  (deleted after extraction)
 namespace Install {
-// Download the binary archive `asset` from a github `release` and extract it
-// to the extension's global storage location.
-// The `abort` controller is signaled if the user cancels the installation.
-// Returns the absolute path to the installed clangd executable.
-export async function install(release: Github.Release, asset: Github.Asset,
-                              abort: AbortController, ui: UI): Promise<string> {
-  const dirs = await createDirs(ui);
-  const extractRoot = path.join(dirs.install, release.tag_name);
-  if (await promisify(fs.exists)(extractRoot)) {
-    const reuse = await ui.shouldReuse(release.name);
-    if (reuse === undefined) {
-      // User dismissed prompt, bail out.
-      abort.abort();
-      throw new Error(`clangd ${release.name} already installed!`);
+  // Download the binary archive `asset` from a github `release` and extract it
+  // to the extension's global storage location.
+  // The `abort` controller is signaled if the user cancels the installation.
+  // Returns the absolute path to the installed clangd executable.
+  export async function install(release: Github.Release, asset: Github.Asset,
+    abort: AbortController, ui: UI): Promise<string> {
+    const dirs = await createDirs(ui);
+    const extractRoot = path.join(dirs.install, release.tag_name);
+    if (await promisify(fs.exists)(extractRoot)) {
+      const reuse = await ui.shouldReuse(release.name);
+      if (reuse === undefined) {
+        // User dismissed prompt, bail out.
+        abort.abort();
+        throw new Error(`clangd ${release.name} already installed!`);
+      }
+      if (reuse) {
+        // Find clangd within the existing directory.
+        let files = (await readdirp.promise(extractRoot)).map(e => e.fullPath);
+        return findExecutable(files);
+      } else {
+        // Delete the old version.
+        await promisify(rimraf)(extractRoot);
+        // continue with installation.
+      }
     }
-    if (reuse) {
-      // Find clangd within the existing directory.
-      let files = (await readdirp.promise(extractRoot)).map(e => e.fullPath);
-      return findExecutable(files);
-    } else {
-      // Delete the old version.
-      await promisify(rimraf)(extractRoot);
-      // continue with installation.
-    }
+    const zipFile = path.join(dirs.download, asset.name);
+    await download(asset.browser_download_url, zipFile, abort, ui);
+    const zip = new AdmZip(zipFile);
+    await ui.slow(ui.localize('Extracting {0}', asset.name), new Promise(resolve => {
+      zip.extractAllToAsync(extractRoot, true, false, resolve);
+    }));
+    const executable = findExecutable(zip.getEntries().map(e => e.entryName));
+    const clangdPath = path.join(extractRoot, executable);
+    await fs.promises.chmod(clangdPath, 0o755);
+    await fs.promises.unlink(zipFile);
+    return clangdPath;
   }
-  const zipFile = path.join(dirs.download, asset.name);
-  await download(asset.browser_download_url, zipFile, abort, ui);
-  const zip = new AdmZip(zipFile);
-  await ui.slow(ui.localize(`Extracting {0}`, asset.name), new Promise(resolve => {
-                  zip.extractAllToAsync(extractRoot, true, false, resolve);
-                }));
-  const executable = findExecutable(zip.getEntries().map(e => e.entryName));
-  const clangdPath = path.join(extractRoot, executable);
-  await fs.promises.chmod(clangdPath, 0o755);
-  await fs.promises.unlink(zipFile);
-  return clangdPath;
-}
 
-// Create the 'install' and 'download' directories, and return absolute paths.
-async function createDirs(ui: UI) {
-  const install = path.join(ui.storagePath, 'install');
-  const download = path.join(ui.storagePath, 'download');
-  for (const dir of [install, download])
-    await fs.promises.mkdir(dir, {'recursive': true});
-  return {install: install, download: download};
-}
+  // Create the 'install' and 'download' directories, and return absolute paths.
+  async function createDirs(ui: UI) {
+    const install = path.join(ui.storagePath, 'install');
+    const download = path.join(ui.storagePath, 'download');
+    for (const dir of [install, download])
+      await fs.promises.mkdir(dir, { 'recursive': true });
+    return { install: install, download: download };
+  }
 
-// Find the clangd executable within a set of files.
-function findExecutable(paths: string[]): string {
-  const filename = os.platform() == 'win32' ? 'clangd.exe' : 'clangd';
-  const entry = paths.find(f => path.posix.basename(f) == filename ||
-                                path.win32.basename(f) == filename);
-  if (entry == null)
-    throw new Error('Didn\'t find a clangd executable!');
-  return entry;
-}
+  // Find the clangd executable within a set of files.
+  function findExecutable(paths: string[]): string {
+    const filename = os.platform() == 'win32' ? 'clangd.exe' : 'clangd';
+    const entry = paths.find(f => path.posix.basename(f) == filename ||
+      path.win32.basename(f) == filename);
+    if (entry == null)
+      throw new Error('Didn\'t find a clangd executable!');
+    return entry;
+  }
 
-// Downloads `url` to a local file `dest` (whose parent should exist).
-// A progress dialog is shown, if it is cancelled then `abort` is signaled.
-async function download(url: string, dest: string, abort: AbortController,
-                        ui: UI): Promise<void> {
-  console.log('Downloading ', url, ' to ', dest);
-  return ui.progress(
-        ui.localize(`Downloading {0}`, path.basename(dest)), abort, async (progress) => {
-        const response = await fetch(url, {signal: abort.signal});
+  // Downloads `url` to a local file `dest` (whose parent should exist).
+  // A progress dialog is shown, if it is cancelled then `abort` is signaled.
+  async function download(url: string, dest: string, abort: AbortController,
+    ui: UI): Promise<void> {
+    console.log('Downloading ', url, ' to ', dest);
+    return ui.progress(
+      ui.localize('Downloading {0}', path.basename(dest)), abort, async (progress) => {
+        const response = await fetch(url, { signal: abort.signal });
         if (!response.ok)
           throw new Error(`Failed to download ${url}`);
         const size = Number(response.headers.get('content-length'));
@@ -317,7 +315,7 @@ async function download(url: string, dest: string, abort: AbortController,
           throw e;
         });
       });
-}
+  }
 }
 
 // Functions dealing with clangd versions.
@@ -329,76 +327,76 @@ async function download(url: string, dest: string, abort: AbortController,
 // These functions throw if versions can't be parsed (e.g. installed clangd
 // is a vendor-modified version).
 namespace Version {
-export async function upgrade(release: Github.Release, clangdPath: string) {
-  const releasedVer = released(release);
-  const installedVer = await installed(clangdPath);
-  return {
-    old: installedVer.raw,
-    new: releasedVer.raw,
-    upgrade: rangeGreater(releasedVer, installedVer)
+  export async function upgrade(release: Github.Release, clangdPath: string) {
+    const releasedVer = released(release);
+    const installedVer = await installed(clangdPath);
+    return {
+      old: installedVer.raw,
+      new: releasedVer.raw,
+      upgrade: rangeGreater(releasedVer, installedVer)
+    };
+  }
+
+  const loose: semver.Options = {
+    'loose': true
   };
-}
 
-const loose: semver.Options = {
-  'loose': true
-};
-
-// Get the version of an installed clangd binary using `clangd --version`.
-async function installed(clangdPath: string): Promise<semver.Range> {
-  const output = await run(clangdPath, ['--version']);
-  console.log(clangdPath, ' --version output: ', output);
-  const prefix = 'clangd version ';
-  const pos = output.indexOf(prefix);
-  if (pos < 0)
-    throw new Error(`Couldn't parse clangd --version output: ${output}`);
-  if (pos > 0) {
-    const vendor = output.substring(0, pos).trim();
-    if (vendor == 'Apple')
-      throw new Error(`Cannot compare vendor's clangd version: ${output}`);
+  // Get the version of an installed clangd binary using `clangd --version`.
+  async function installed(clangdPath: string): Promise<semver.Range> {
+    const output = await run(clangdPath, ['--version']);
+    console.log(clangdPath, ' --version output: ', output);
+    const prefix = 'clangd version ';
+    const pos = output.indexOf(prefix);
+    if (pos < 0)
+      throw new Error(`Couldn't parse clangd --version output: ${output}`);
+    if (pos > 0) {
+      const vendor = output.substring(0, pos).trim();
+      if (vendor == 'Apple')
+        throw new Error(`Cannot compare vendor's clangd version: ${output}`);
+    }
+    // Some vendors add trailing ~patchlevel, ignore this.
+    const rawVersion = output.substr(pos + prefix.length).split(/\s|~/, 1)[0];
+    return new semver.Range(rawVersion, loose);
   }
-  // Some vendors add trailing ~patchlevel, ignore this.
-  const rawVersion = output.substr(pos + prefix.length).split(/\s|~/, 1)[0];
-  return new semver.Range(rawVersion, loose);
-}
 
-// Get the version of a github release, by parsing the tag or name.
-function released(release: Github.Release): semver.Range {
-  // Prefer the tag name, but fall back to the release name.
-  return (!semver.validRange(release.tag_name, loose) &&
-          semver.validRange(release.name, loose))
-             ? new semver.Range(release.name, loose)
-             : new semver.Range(release.tag_name, loose);
-}
-
-// Detect the (linux) system's glibc version. If older than `min`, return it.
-export async function oldGlibc(min: semver.Range): Promise<semver.Range|null> {
-  // ldd is distributed with glibc, so ldd --version should be a good proxy.
-  const output = await run(lddCommand, ['--version']);
-  // The first line is e.g. "ldd (Debian GLIBC 2.29-9) 2.29".
-  const line = output.split('\n', 1)[0];
-  // Require some confirmation this is [e]glibc, and a plausible
-  // version number.
-  const match = line.match(/^ldd .*glibc.* (\d+(?:\.\d+)+)[^ ]*$/i);
-  if (!match || !semver.validRange(match[1], loose)) {
-    console.error(`Can't glibc version from ldd --version output: ${line}`);
-    return null;
+  // Get the version of a github release, by parsing the tag or name.
+  function released(release: Github.Release): semver.Range {
+    // Prefer the tag name, but fall back to the release name.
+    return (!semver.validRange(release.tag_name, loose) &&
+      semver.validRange(release.name, loose))
+      ? new semver.Range(release.name, loose)
+      : new semver.Range(release.tag_name, loose);
   }
-  const version = new semver.Range(match[1], loose);
-  console.log('glibc is', version.raw, 'min is', min.raw);
-  return rangeGreater(min, version) ? version : null;
-}
 
-// Run a system command and capture any stdout produced.
-async function run(command: string, flags: string[]): Promise<string> {
-  const child = child_process.spawn(command, flags,
-                                    {stdio: ['ignore', 'pipe', 'ignore']});
-  let output = '';
-  for await (const chunk of child.stdout)
-    output += chunk;
-  return output;
-}
+  // Detect the (linux) system's glibc version. If older than `min`, return it.
+  export async function oldGlibc(min: semver.Range): Promise<semver.Range | null> {
+    // ldd is distributed with glibc, so ldd --version should be a good proxy.
+    const output = await run(lddCommand, ['--version']);
+    // The first line is e.g. "ldd (Debian GLIBC 2.29-9) 2.29".
+    const line = output.split('\n', 1)[0];
+    // Require some confirmation this is [e]glibc, and a plausible
+    // version number.
+    const match = line.match(/^ldd .*glibc.* (\d+(?:\.\d+)+)[^ ]*$/i);
+    if (!match || !semver.validRange(match[1], loose)) {
+      console.error(`Can't glibc version from ldd --version output: ${line}`);
+      return null;
+    }
+    const version = new semver.Range(match[1], loose);
+    console.log('glibc is', version.raw, 'min is', min.raw);
+    return rangeGreater(min, version) ? version : null;
+  }
 
-function rangeGreater(newVer: semver.Range, oldVer: semver.Range) {
-  return semver.gtr(semver.minVersion(newVer), oldVer);
-}
+  // Run a system command and capture any stdout produced.
+  async function run(command: string, flags: string[]): Promise<string> {
+    const child = child_process.spawn(command, flags,
+      { stdio: ['ignore', 'pipe', 'ignore'] });
+    let output = '';
+    for await (const chunk of child.stdout)
+      output += chunk;
+    return output;
+  }
+
+  function rangeGreater(newVer: semver.Range, oldVer: semver.Range) {
+    return semver.gtr(semver.minVersion(newVer), oldVer);
+  }
 }

--- a/test/index.ts
+++ b/test/index.ts
@@ -66,10 +66,10 @@ class FakeUI {
     this.event('progress');
     return work((fraction) => console.log('progress% ', 100 * fraction));
   }
-  localize(message: string, ...args: string[]): string {
+  localize(message: string, ...args: Array<string | number | boolean>): string {
     let ret = message
     for(const i in args){
-      ret.replace(`{${i}}`,args[i])
+      ret.replace(`{${i}}`,args[i].toString())
     }
     return ret
   }

--- a/test/index.ts
+++ b/test/index.ts
@@ -5,6 +5,7 @@ import * as os from 'os';
 import * as path from 'path';
 import * as tape from 'tape';
 import * as tmp from 'tmp-promise';
+
 import * as install from '../src/index';
 
 const oldClangd = process.cwd() + '/test/assets/fake-clangd-5/clangd';
@@ -66,10 +67,10 @@ class FakeUI {
     this.event('progress');
     return work((fraction) => console.log('progress% ', 100 * fraction));
   }
-  localize(message: string, ...args: Array<string | number | boolean>): string {
+  localize(message: string, ...args: Array<string|number|boolean>): string {
     let ret = message;
-    for(const i in args){
-      ret.replace(`{${i}}`,args[i].toString());
+    for (const i in args) {
+      ret.replace(`{${i}}`, args[i].toString());
     }
     return ret;
   }
@@ -100,7 +101,6 @@ function test(name: string,
                          });
     });
   }, {unsafeCleanup: true}));
-  
 }
 
 // Test the actual installation, typically the clangd.install command.

--- a/test/index.ts
+++ b/test/index.ts
@@ -66,6 +66,13 @@ class FakeUI {
     this.event('progress');
     return work((fraction) => console.log('progress% ', 100 * fraction));
   }
+  localize(message: string, ...args: string[]): string {
+    let ret = message
+    for(const i in args){
+      ret.replace(`{${i}}`,args[i])
+    }
+    return ret
+  }
 };
 
 function test(name: string,
@@ -93,6 +100,7 @@ function test(name: string,
                          });
     });
   }, {unsafeCleanup: true}));
+  
 }
 
 // Test the actual installation, typically the clangd.install command.

--- a/test/index.ts
+++ b/test/index.ts
@@ -67,11 +67,11 @@ class FakeUI {
     return work((fraction) => console.log('progress% ', 100 * fraction));
   }
   localize(message: string, ...args: Array<string | number | boolean>): string {
-    let ret = message
+    let ret = message;
     for(const i in args){
-      ret.replace(`{${i}}`,args[i].toString())
+      ret.replace(`{${i}}`,args[i].toString());
     }
-    return ret
+    return ret;
   }
 };
 


### PR DESCRIPTION
I am implementing l10n support in vscode-clangd. However, I discovered that we are unable to localize the messages sent by node-clang. Thanks to @HighCommander4 suggestion, I have now add the "localize" function for the type UI. This function allows us to localize the messages sent by node-clang.

I will add the localize impl for coc-clangd, after the npm package is published, 

Refer: https://github.com/clangd/vscode-clangd/issues/560#issuecomment-1851396451