### PR TITLE
Update Node used to publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,8 +6,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
-        with:
-          node-version: 12
       - run: npm ci
       - run: npm test
       - uses: JS-DevTools/npm-publish@v3


### PR DESCRIPTION
Use the action's default version, matching CI.