### PR TITLE
fix: lock adm-zip to version 0.5.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.19",
       "license": "Apache-2.0 WITH LLVM-exception",
       "dependencies": {
-        "adm-zip": "^0.5.14",
+        "adm-zip": "0.5.12",
         "node-fetch": "^2.7.0",
         "readdirp": "^4.1.1",
         "rimraf": "^6.0.1",
@@ -160,12 +160,12 @@
       "license": "MIT"
     },
     "node_modules/adm-zip": {
-      "version": "0.5.16",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
-      "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
+      "version": "0.5.12",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.12.tgz",
+      "integrity": "sha512-6TVU49mK6KZb4qG6xWaaM4C7sA/sgUMLy/JYMOzkcp3BvVLpW0fXDFQiIzAuxFCt/2+xD7fNIiPFAoLZPhVNLQ==",
       "license": "MIT",
       "engines": {
-        "node": ">=12.0"
+        "node": ">=6.0"
       }
     },
     "node_modules/ansi-regex": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "url": "https://github.com/clangd/node-clangd/issues"
   },
   "dependencies": {
-    "adm-zip": "^0.5.14",
+    "adm-zip": "0.5.12",
     "node-fetch": "^2.7.0",
     "readdirp": "^4.1.1",
     "rimraf": "^6.0.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -323,8 +323,13 @@ namespace Install {
     }
     await ui.slow(
       ui.localize('Extracting {0}', asset.name),
-      new Promise((resolve) => {
-        zip.extractAllToAsync(extractRoot, true, false, resolve);
+      new Promise<void>((resolve, reject) => {
+        try {
+          zip.extractAllTo(extractRoot, true, false);
+          resolve();
+        } catch (err) {
+          reject(err);
+        }
       }),
     );
     const clangdPath = path.join(extractRoot, executable.entryName);


### PR DESCRIPTION
0.5.13+ is broken, extract empty results

- https://github.com/cthackers/adm-zip/issues/538
- https://github.com/fannheyward/coc-rust-analyzer/issues/1281