### PR TITLE
Replace adm-zip with yauzl

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,15 +9,14 @@
       "version": "0.1.19",
       "license": "Apache-2.0 WITH LLVM-exception",
       "dependencies": {
-        "adm-zip": "^0.5.14",
         "node-fetch": "^2.7.0",
         "readdirp": "^4.1.1",
         "rimraf": "^6.0.1",
         "semver": "^7.6.3",
-        "which": "^5.0.0"
+        "which": "^5.0.0",
+        "yauzl": "^3.2.0"
       },
       "devDependencies": {
-        "@types/adm-zip": "^0.5.5",
         "@types/node": "^22.0.2",
         "@types/node-fetch": "^2.6.11",
         "@types/node-static": "^0.7.11",
@@ -25,6 +24,7 @@
         "@types/tape": "^5.6.4",
         "@types/tmp": "^0.2.6",
         "@types/which": "^3.0.4",
+        "@types/yauzl": "^2.10.3",
         "node-static": "^0.7.11",
         "prettier": "^3.3.3",
         "tap-spec": "^5.0.0",
@@ -75,16 +75,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/@types/adm-zip": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/@types/adm-zip/-/adm-zip-0.5.7.tgz",
-      "integrity": "sha512-DNEs/QvmyRLurdQPChqq0Md4zGvPwHerAJYWk9l2jCbD1VPpnzRJorOdiq4zsw09NFbYnhfsoEhWtxIzXpn2yw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "node_modules/@types/mime": {
@@ -159,13 +149,14 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/adm-zip": {
-      "version": "0.5.16",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
-      "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "dev": true,
       "license": "MIT",
-      "engines": {
-        "node": ">=12.0"
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/ansi-regex": {
@@ -295,6 +286,15 @@
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/buffer-shims": {
@@ -1986,6 +1986,12 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "license": "MIT"
+    },
     "node_modules/plur": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/plur/-/plur-1.0.0.tgz",
@@ -3218,6 +3224,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.2.0.tgz",
+      "integrity": "sha512-Ow9nuGZE+qp1u4JIPvg+uCiUr7xGQWdff7JQSk5VGYTAZMDe2q8lxJ10ygv10qmSj031Ty/6FNJpLO4o1Sgc+w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "pend": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -26,15 +26,14 @@
     "url": "https://github.com/clangd/node-clangd/issues"
   },
   "dependencies": {
-    "adm-zip": "^0.5.14",
     "node-fetch": "^2.7.0",
     "readdirp": "^4.1.1",
     "rimraf": "^6.0.1",
     "semver": "^7.6.3",
-    "which": "^5.0.0"
+    "which": "^5.0.0",
+    "yauzl": "^3.2.0"
   },
   "devDependencies": {
-    "@types/adm-zip": "^0.5.5",
     "@types/node": "^22.0.2",
     "@types/node-fetch": "^2.6.11",
     "@types/node-static": "^0.7.11",
@@ -42,6 +41,7 @@
     "@types/tape": "^5.6.4",
     "@types/tmp": "^0.2.6",
     "@types/which": "^3.0.4",
+    "@types/yauzl": "^2.10.3",
     "node-static": "^0.7.11",
     "prettier": "^3.3.3",
     "tap-spec": "^5.0.0",


### PR DESCRIPTION
All adm-zip versions after 0.5.10 seem to have bugs:
- 0.5.11 causes tests to fail.
- 0.5.12 causes tests to hang.
- 0.5.13 causes extracted files to be empty.

This also avoids extracting anything other than the clangd binary.

This is an alternative to #34.
