### PR TITLE
Release version 0.1.20

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@clangd/install",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@clangd/install",
-      "version": "0.1.19",
+      "version": "0.1.20",
       "license": "Apache-2.0 WITH LLVM-exception",
       "dependencies": {
         "node-fetch": "^2.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clangd/install",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "description": "Installing clangd binaries from editor plugins.",
   "main": "out/src/index.js",
   "files": [


### PR DESCRIPTION
This releases the change in #36 to work around bugs in 'adm-zip' by switching to 'unzipper'.